### PR TITLE
Rename jsonifier

### DIFF
--- a/src/youtube_channel_data/core.clj
+++ b/src/youtube_channel_data/core.clj
@@ -15,7 +15,7 @@
   [video-id]
   (->> (yt/videos {:part "snippet" :id video-id})
        (slurp)
-       (u/video->json)
+       (u/video->clj)
        (:items)
        (first)
        (:snippet)
@@ -25,10 +25,10 @@
   "Returns vec with [playlist-id, title]"
   [channel-id]
   (let [channel-item (->> (yt/channels {:part "contentDetails,brandingSettings" :id channel-id})
-       (slurp)
-       (u/channel->json)
-       (:items)
-               (first))]
+                      (slurp)
+                      (u/channel->clj)
+                      (:items)
+                      (first))]
     [(get-in channel-item [:contentDetails :relatedPlaylists :uploads])
      (get-in channel-item [:brandingSettings :channel :title])]))
 
@@ -57,13 +57,13 @@
   ([url]
    (let [converted (-> url
                        (slurp)
-                       (u/playlist->json))]
+                       (u/playlist->clj))]
      (consume-playlist-pages (conj [] (:items converted)) url (:nextPageToken converted))))
   ([items-coll base-url page-token]
    (if page-token
      (let [converted (-> (str base-url "&" (u/query-params->query-string {:pageToken page-token}))
                          (slurp)
-                         (u/playlist->json))]
+                         (u/playlist->clj))]
        (recur (conj items-coll (:items converted)) base-url (:nextPageToken converted)))
      items-coll)))
 
@@ -72,14 +72,14 @@
   [base-url ids]
   (-> (str base-url "&" (u/query-params->query-string {:id (str/join "," ids)}))
       (slurp)
-      (u/video->json)
+      (u/video->clj)
       (:items)))
 
 (defn transform-playlist-items
   "Transform playlist-items & videos to output map"
   [playlist-items videos]
-  (map output/output-map playlist-items videos)
-  )
+  (map output/output-map playlist-items videos))
+
 
 (defn add-video-title-filter
   [{{filter-option :filter} :options :as data}]

--- a/src/youtube_channel_data/utils.clj
+++ b/src/youtube_channel_data/utils.clj
@@ -14,7 +14,7 @@
     :publishedAt (ZonedDateTime/parse value) ; https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/ZonedDateTime.html
     value))
 
-(defn json-str->clj
+(defn json->clj
   [value-fn-func]
   (fn
     [json-str]
@@ -22,11 +22,11 @@
                    :value-fn value-fn-func ; each key/value will go through this function
                    :key-fn keyword)))
 
-(def channel->clj (json-str->clj (fn [_k v] v)))
+(def channel->clj (json->clj (fn [_k v] v)))
 
-(def playlist->clj (json-str->clj json-value-reader))
+(def playlist->clj (json->clj json-value-reader))
 
-(def video->clj (json-str->clj json-value-reader))
+(def video->clj (json->clj json-value-reader))
 
 ; Others
 (defn parse-input

--- a/src/youtube_channel_data/utils.clj
+++ b/src/youtube_channel_data/utils.clj
@@ -14,7 +14,7 @@
     :publishedAt (ZonedDateTime/parse value) ; https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/ZonedDateTime.html
     value))
 
-(defn str->json
+(defn json-str->clj
   [value-fn-func]
   (fn
     [json-str]
@@ -22,11 +22,11 @@
                    :value-fn value-fn-func ; each key/value will go through this function
                    :key-fn keyword)))
 
-(def channel->json (str->json (fn [_k v] v)))
+(def channel->clj (json-str->clj (fn [_k v] v)))
 
-(def playlist->json (str->json json-value-reader))
+(def playlist->clj (json-str->clj json-value-reader))
 
-(def video->json (str->json json-value-reader))
+(def video->clj (json-str->clj json-value-reader))
 
 ; Others
 (defn parse-input

--- a/test/youtube_channel_data/utils_test.clj
+++ b/test/youtube_channel_data/utils_test.clj
@@ -13,11 +13,12 @@
     ; Since JDK 9
     (is (= 6696 (.toSeconds duration-val)))))
 
-(deftest test-str->json
-  (is (= true (fn? (u/str->json u/json-value-reader)))))
+(deftest test-json-str->json
+  (is (= true (fn? (u/json-str->clj u/json-value-reader))))
+  (is (= {:wow "wow" :hey {:yo "hi"}} ((u/json-str->clj (fn [_ v] v)) "{\"wow\": \"wow\", \"hey\": {\"yo\": \"hi\"}}"))))
 
 (deftest test-channel->json
-  (is (= {:a "b"} (u/channel->json "{\"a\": \"b\"}"))))
+  (is (= {:a "b"} (u/channel->clj "{\"a\": \"b\"}"))))
 
 ; tests done in other deftests
 (deftest test-playlist->json)

--- a/test/youtube_channel_data/utils_test.clj
+++ b/test/youtube_channel_data/utils_test.clj
@@ -13,9 +13,9 @@
     ; Since JDK 9
     (is (= 6696 (.toSeconds duration-val)))))
 
-(deftest test-json-str->json
-  (is (= true (fn? (u/json-str->clj u/json-value-reader))))
-  (is (= {:wow "wow" :hey {:yo "hi"}} ((u/json-str->clj (fn [_ v] v)) "{\"wow\": \"wow\", \"hey\": {\"yo\": \"hi\"}}"))))
+(deftest test-json->clj
+  (is (= true (fn? (u/json->clj u/json-value-reader))))
+  (is (= {:wow "wow" :hey {:yo "hi"}} ((u/json->clj (fn [_ v] v)) "{\"wow\": \"wow\", \"hey\": {\"yo\": \"hi\"}}"))))
 
 (deftest test-channel->json
   (is (= {:a "b"} (u/channel->clj "{\"a\": \"b\"}"))))


### PR DESCRIPTION
In utils, it said said `video->json`. Here's what the `slurp` provides:

```clojure
(slurp (yt/videos {:part "snippet" :id video-id}))
=>
"{
   \"kind\": \"youtube#videoListResponse\",
   \"etag\": \"Mt4AlP7m9As1Rvipj3QijJcv9Vw\",
   \"items\": [ ...more json ] ...}"
```
That's json. Here's what `video->json` does:

```clojure
(u/video->json (slurp (yt/videos {:part "snippet" :id video-id})))
=>
{:kind "youtube#videoListResponse",
 :etag "Mt4AlP7m9As1Rvipj3QijJcv9Vw",
 :items [{:kind "youtube#video", ...more clj }]}
```

So I renamed things to `...->clj`. Added a test, too. 