### PR TITLE
add -main docstring

### DIFF
--- a/src/youtube_channel_data/core.clj
+++ b/src/youtube_channel_data/core.clj
@@ -133,6 +133,11 @@
     :default "csv"]])
 
 (defn -main
+  "Start the app. Key examples:
+
+   options: {:output csv}, {:output csv, :filter \"twosday\"}
+   arguments: [\"1DQ0j_9Pq-g\"]
+   summary: \"The system cannot find the path specified...\""
   [& args]
   (let [{:keys [options arguments _errors summary]} (parse-opts args cli-options)]
     (if (empty? arguments)


### PR DESCRIPTION
Had to figure out what `options`, `arguments`, `_errors`, and `summary` were for testing. Posted example findings in the `-main` docstring. 